### PR TITLE
Support pytest 4.1.0

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+2.0.0 (2019/01/10)
+------------------
+
+ - Replace deprecated Node.get_marker() [pytest #4546](https://github.com/pytest-dev/pytest/issues/4546) with Node.get_closest_marker()
+
+
 1.2.0 (2018/12/23)
 ------------------
 

--- a/pytest_only/plugin.py
+++ b/pytest_only/plugin.py
@@ -14,7 +14,7 @@ def pytest_collection_modifyitems(config, items):
 
     only, other = [], []
     for item in items:
-        l = only if item.get_marker('only') else other
+        l = only if item.get_closest_marker('only') else other
         l.append(item)
 
     if only:

--- a/pytest_only/version.py
+++ b/pytest_only/version.py
@@ -1,2 +1,2 @@
-VERSION = (1, 2, 0)
+VERSION = (2, 0, 0)
 __version__ = '.'.join(str(n) for n in VERSION)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pytest
+pytest>4.1.0


### PR DESCRIPTION
My first attempt a PR. 

I upgraded to pytest 4.1.0 and ran into the deprecation of the node.get_marker function.

https://github.com/pytest-dev/pytest/issues/4546