### PR TITLE
use Node.get_closest_marker

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+UNRELEASED
+----------
+
+ - Switch to Node.get_closest_marker, Node.get_marker was removed in pytest 4.1.0 (requires pytest >= 3.6)
+
+
 1.2.0 (2018/12/23)
 ------------------
 

--- a/pytest_only/plugin.py
+++ b/pytest_only/plugin.py
@@ -14,7 +14,7 @@ def pytest_collection_modifyitems(config, items):
 
     only, other = [], []
     for item in items:
-        l = only if item.get_marker('only') else other
+        l = only if item.get_closest_marker('only') else other
         l.append(item)
 
     if only:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pytest
+pytest>=3.6  # Node.get_closest_marker


### PR DESCRIPTION
Pytest 4.1 dropped Node.get_marker.

this PR switches to get_closest_marker and adds a requirement for `pytest>=3.6`

See alternate: #6