### PR TITLE
prefer Node.get_closest_marker

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+UNRELEASED
+----------
+
+ - Prefer Node.get_closest_marker (Node.get_marker was removed in pytest 4.1.0)
+
+
 1.2.0 (2018/12/23)
 ------------------
 

--- a/pytest_only/plugin.py
+++ b/pytest_only/plugin.py
@@ -8,13 +8,25 @@ def pytest_addoption(parser):
                      help='Disable --only filtering')
 
 
+def get_closest_marker(item):
+    # get_closest_marker added in ptest 3.6
+    # https://docs.pytest.org/en/latest/changelog.html#pytest-3-6-0-2018-05-23
+    # get_marker removed in pytest 4.1
+    # https://docs.pytest.org/en/latest/changelog.html#pytest-4-1-0-2019-01-05
+    if hasattr(item, 'get_closest_marker'):
+        fn = 'get_closest_marker'
+    else:
+        fn = 'get_marker'
+    return getattr(item, fn)('only')
+
+
 def pytest_collection_modifyitems(config, items):
     if not config.getoption('--only'):
         return
 
     only, other = [], []
     for item in items:
-        l = only if item.get_marker('only') else other
+        l = only if get_closest_marker(item) else other
         l.append(item)
 
     if only:


### PR DESCRIPTION
Pytest 4.1 dropped Node.get_marker.

this PR adds a preference to use `get_closest_marker`, otherwise it falls back to `get_marker`

Alternate to #5