### PR TITLE
FIX: use get_closest_marker where available, for 4.1.0 compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 dist/
 
 .idea/
+
+# testing
+.pytest_cache
+.tox

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+UNRELEASED
+----------
+
+ - Fix get_marker usage for compatibility with pytest 4.1.0 (see https://github.com/pytest-dev/pytest/issues/4546)
+
+
 1.2.0 (2018/12/23)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -134,3 +134,25 @@ If ``--no-only`` has already been passed (perhaps by way of ``addopts`` in
 .. code-block:: bash
 
     $ py.test --no-only --only
+
+
+Development
+-----------
+
+1. Install the test/dev requirements
+
+    .. code-block:: bash
+
+        $ pip install -r dev-requirements.txt
+
+2. Run the tests
+
+    .. code-block:: bash
+
+        $ py.test
+
+3. Run the tests on all currently-supported platforms
+
+    .. code-block:: bash
+
+        $ tox

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+
+tox==3.6.1

--- a/pytest_only/compat.py
+++ b/pytest_only/compat.py
@@ -1,11 +1,15 @@
 import pytest
-from _pytest.nodes import Node
+
+try:
+    from _pytest.nodes import Node
+except ImportError:
+    from _pytest.main import Node
 
 
 if hasattr(Node, 'get_closest_marker'):
-    get_closest_marker = Node.get_closest_marker
+    get_closest_marker = lambda item, *a, **kw: item.get_closest_marker(*a, **kw)
 elif hasattr(Node, 'get_marker'):
-    get_closest_marker = Node.get_marker
+    get_closest_marker = lambda item, *a, **kw: item.get_marker(*a, **kw)
 else:
     raise RuntimeError(
         'Unable to determine get_closest_marker alternative '

--- a/pytest_only/compat.py
+++ b/pytest_only/compat.py
@@ -1,0 +1,12 @@
+import pytest
+from _pytest.nodes import Node
+
+
+if hasattr(Node, 'get_closest_marker'):
+    get_closest_marker = Node.get_closest_marker
+elif hasattr(Node, 'get_marker'):
+    get_closest_marker = Node.get_marker
+else:
+    raise RuntimeError(
+        'Unable to determine get_closest_marker alternative '
+        'for pytest version {}'.format(pytest.__version__))

--- a/pytest_only/plugin.py
+++ b/pytest_only/plugin.py
@@ -1,3 +1,6 @@
+from .compat import get_closest_marker
+
+
 def pytest_addoption(parser):
     parser.addoption('--only', dest='enable_only',
                      default=True, action='store_true',
@@ -14,7 +17,7 @@ def pytest_collection_modifyitems(config, items):
 
     only, other = [], []
     for item in items:
-        l = only if item.get_marker('only') else other
+        l = only if get_closest_marker(item, 'only') else other
         l.append(item)
 
     if only:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pytest>=3.6
+pytest>=2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pytest
+pytest>=3.6

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -10,7 +10,9 @@ pytest_plugins = 'pytester'
 def setup_syspath(testdir):
     repo_dir = os.path.dirname(os.path.dirname(__file__))
     testdir.syspathinsert(repo_dir)
-    testdir.makeconftest('pytest_plugins = "pytest_only.plugin"')
+    testdir.makeconftest('pytest_plugins = ["pytest_only.plugin"]')
+    testdir.makeini('[pytest]\n'
+                    'addopts = -p no:only')
 
 
 def assert_test_did_run(res, name):
@@ -36,7 +38,7 @@ def test_function(testdir):
         def test_should_also_not_run():
             pass
     ''')
-    res = testdir.runpytest_inprocess(file, '--verbose')
+    res = testdir.runpytest(file, '--verbose')
     outcomes = res.parseoutcomes()
     assert 'passed' in outcomes, 'Tests did not run successfully'
     assert outcomes['passed'] == 1, 'Incorrect number of tests passed'
@@ -65,7 +67,7 @@ def test_class(testdir):
             def test_should_also_not_run(self):
                 pass
     ''')
-    res = testdir.runpytest_inprocess(file, '--verbose')
+    res = testdir.runpytest(file, '--verbose')
     outcomes = res.parseoutcomes()
     assert 'passed' in outcomes, 'Tests did not run successfully'
     assert outcomes['passed'] == 2, 'Incorrect number of tests passed'
@@ -94,7 +96,7 @@ def test_file(testdir):
             pass
     ''')
 
-    res = testdir.runpytest_inprocess('--verbose', should_run, should_not_run)
+    res = testdir.runpytest('--verbose', should_run, should_not_run)
     outcomes = res.parseoutcomes()
     assert 'passed' in outcomes, 'Tests did not run successfully'
     assert outcomes['passed'] == 2, 'Incorrect number of tests passed'
@@ -118,7 +120,7 @@ def test_no_only_cmdline_option(testdir):
         def test_should_also_run():
             pass
     ''')
-    res = testdir.runpytest_inprocess(file, '--verbose', '--no-only')
+    res = testdir.runpytest(file, '--verbose', '--no-only')
     outcomes = res.parseoutcomes()
     assert 'passed' in outcomes, 'Tests did not run successfully'
 
@@ -141,7 +143,7 @@ def test_negating_cmdline_options(testdir):
         def test_should_also_not_run():
             pass
     ''')
-    res = testdir.runpytest_inprocess(file, '--verbose', '--no-only', '--only')
+    res = testdir.runpytest(file, '--verbose', '--no-only', '--only')
     outcomes = res.parseoutcomes()
     assert 'passed' in outcomes, 'Tests did not run successfully'
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+envlist =
+    {py27,py35,py36,py37}-{pytest36,pytest40}
+    {py27,py35,py36,py37}-pytest41
+
+
+[testenv]
+commands = py.test
+setenv = PYTEST_DISABLE_PLUGIN_AUTOLOAD = 1
+
+deps =
+    pytest36: pytest>=3.6,<3.7
+    pytest40: pytest>=4.0,<4.1
+    pytest41: pytest>=4.1,<4.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    {py27,py35,py36,py37}-{pytest36,pytest40}
-    {py27,py35,py36,py37}-pytest41
+    {py27,py35,py36,py37}-{pytest26,pytest29,pytest36,pytest40,pytest41}
 
 
 [testenv]
@@ -9,6 +8,8 @@ commands = py.test
 setenv = PYTEST_DISABLE_PLUGIN_AUTOLOAD = 1
 
 deps =
+    pytest26: pytest>=2.6,<2.7
+    pytest29: pytest>=2.9,<3.0
     pytest36: pytest>=3.6,<3.7
     pytest40: pytest>=4.0,<4.1
     pytest41: pytest>=4.1,<4.2


### PR DESCRIPTION
[pytest 4.1.0 removed the get_marker method](https://docs.pytest.org/en/latest/mark.html#marker-revamp-and-iteration). To support older versions and 4.1.0, this PR uses either `Node.get_closest_marker` or `Node.get_marker`, with selection by feature detection.

Shoutout to @rib3 and @madzim for the johnny-on-the-spot PRs, which were how I found out about the removals. So much for semver :P