### PR TITLE
Merge pull request #8 from nicoddemus/patch-1

### DIFF
--- a/pytest_only/plugin.py
+++ b/pytest_only/plugin.py
@@ -9,6 +9,12 @@ def pytest_addoption(parser):
     parser.addoption('--no-only', dest='enable_only',
                      action='store_false',
                      help='Disable --only filtering')
+    
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "only: normal runs will execute only marked tests"
+    )    
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
Since pytest [4.5.0](https://github.com/pytest-dev/pytest/blob/master/doc/en/changelog.rst#pytest-450-2019-05-11), warnings are emitted for unknown marks.

This PR registers the `only` mark so users don't get the warning message.

Ref: https://github.com/pytest-dev/pytest/issues/6230