### PR TITLE
fix(ext): prevent error from chained assignments in flake8 plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Fixed
+ - Fix for [flake8](https://github.com/PyCQA/flake8) plugin exception on chained assignments (thank you, [@jack-zins](https://github.com/jack-zins) – [GH#13](https://github.com/theY4Kman/pytest-only/pull/13))
 
 
 ## [2.1.2] — 2024-05-27

--- a/pytest_only/ext/flake8.py
+++ b/pytest_only/ext/flake8.py
@@ -110,7 +110,7 @@ def iter_only_mark_pytestmarks(
 
 def get_pytestmark_assign_value(stmt: ast.stmt) -> Optional[ast.expr]:
     if isinstance(stmt, ast.Assign):
-        if len(stmt.targets) == 1:
+        if len(stmt.targets) >= 1:
             if hasattr(stmt.targets[0], 'elts'):
                 targets = stmt.targets[0].elts
                 values = getattr(stmt.value, 'elts', None)

--- a/pytest_only/ext/flake8.py
+++ b/pytest_only/ext/flake8.py
@@ -122,13 +122,15 @@ def iter_assign_targets_values(
     for target in targets:
         if hasattr(target, "elts"):
             if hasattr(value, "elts"):
-                # zip() is safe because the interpreter will raise an exception if
+                # zip() is safe because the interpreter should raise an exception if
                 # there are too few or too many values to unpack
                 for nested_target, nested_value in zip(target.elts, value.elts):
                     yield from iter_assign_targets_values([nested_target], nested_value)
             else:
-                # This is not valid python, cannot unpack non-iterable
-                # We'll let the interpreter handle this
+                # This is probably not valid python "cannot unpack non-iterable"
+                # It's also possible this case could be hit by someone unpacking
+                # a different type of iterable object, and it is beyond the scope of
+                # this extension to attempt to evaluate such cases.
                 pass
         else:
             yield target, value

--- a/pytest_only/ext/flake8.py
+++ b/pytest_only/ext/flake8.py
@@ -122,9 +122,13 @@ def iter_assign_targets_values(
     for target in targets:
         if hasattr(target, "elts"):
             if hasattr(value, "elts"):
+                # zip() is safe because the interpreter will raise an exception if
+                # there are too few or too many values to unpack
                 for nested_target, nested_value in zip(target.elts, value.elts):
                     yield from iter_assign_targets_values([nested_target], nested_value)
             else:
-                pass  # This is not valid python, cannot unpack non-iterable
+                # This is not valid python, cannot unpack non-iterable
+                # We'll let the interpreter handle this
+                pass
         else:
             yield target, value

--- a/test/ext/base_lint.py
+++ b/test/ext/base_lint.py
@@ -243,6 +243,10 @@ class BaseLintTest(CommonSubjectTestMixin):
             
             # Chained assignment should not cause errors
             a = b = 3
+            a = b, c = (0, 1)
+            a = b, *c = (0, 1)
+            a = [b, c] = (0, 1)
+            a = [b, [c, d]], (0, (1, 2))
 
             # Decorators of all kinds should not cause errors
             @staticmethod

--- a/test/ext/base_lint.py
+++ b/test/ext/base_lint.py
@@ -182,6 +182,21 @@ class BaseLintTest(CommonSubjectTestMixin):
                         pass
                 ''')
 
+            class CaseNestedUnpackAssign(IncludesUnexpectedFocused):
+                # language=py
+                source = lambda_fixture(lambda pytestmark_decl: f'''
+                    import pytest
+
+                    pytest._notreal, [pytestmark, _], stuff = 'abc', [{pytestmark_decl}, None], 123
+
+                    class TestMyStuff:
+                        def test_stuff(self):
+                            pass
+
+                    def test_other_stuff():
+                        pass
+                ''')
+
             class CaseChainedAssign(IncludesUnexpectedFocused):
                 assignments = lambda_fixture(params=[
                     pytest.param(('pytestmark', 'stuff'), id='pytestmark-first'),
@@ -208,6 +223,21 @@ class BaseLintTest(CommonSubjectTestMixin):
                     import pytest
 
                     pytest._notreal, [pytestmark, stuff] = 'abc', [{pytestmark_decl}, 123]
+
+                    class TestMyStuff:
+                        def test_stuff(self):
+                            pass
+
+                    def test_other_stuff():
+                        pass
+                ''')
+
+            class CaseChainedAssignWithNestedUnpackAssign(IncludesUnexpectedFocused):
+                # language=py
+                source = lambda_fixture(lambda pytestmark_decl: f'''
+                    import pytest
+
+                    pytest._notreal, [[pytestmark, _], stuff] = 'abc', [[{pytestmark_decl}, None], 123]
 
                     class TestMyStuff:
                         def test_stuff(self):

--- a/test/ext/base_lint.py
+++ b/test/ext/base_lint.py
@@ -183,11 +183,16 @@ class BaseLintTest(CommonSubjectTestMixin):
                 ''')
 
             class CaseChainedAssign(IncludesUnexpectedFocused):
+                assignments = lambda_fixture(params=[
+                    pytest.param(('pytestmark', 'stuff'), id='pytestmark-first'),
+                    pytest.param(('stuff', 'pytestmark'), id='pytestmark-last'),
+                ])
+
                 # language=py
-                source = lambda_fixture(lambda pytestmark_decl: f'''
+                source = lambda_fixture(lambda pytestmark_decl, assignments: f'''
                     import pytest
 
-                    pytestmark = stuff = {pytestmark_decl}
+                    {" = ".join(assignments)} = {pytestmark_decl}
 
                     class TestMyStuff:
                         def test_stuff(self):

--- a/test/ext/base_lint.py
+++ b/test/ext/base_lint.py
@@ -127,15 +127,28 @@ class BaseLintTest(CommonSubjectTestMixin):
                             pass
                 ''')
 
-        class ContextWithoutOnlyMark(DoesNotIncludeUnexpectedFocused):
-            # language=py
-            source = static_fixture('''
-                class TestMyStuff:
-                    apples = 'pears'
+        class ContextWithoutOnlyMark:
+            class CaseNormal(DoesNotIncludeUnexpectedFocused):
+                # language=py
+                source = static_fixture('''
+                    class TestMyStuff:
+                        apples = 'pears'
+    
+                        def test_stuff(self):
+                            pass
+                ''')
 
-                    def test_stuff(self):
-                        pass
-            ''')
+            class CaseOnlyMarkUnpackAssignOther(DoesNotIncludeUnexpectedFocused):
+                # language=py
+                source = static_fixture(
+                    '''
+                    class TestMyStuff:
+                        pytestmark, pytest._notreal, stuff = [], {pytestmark_decl}, 123
+
+                        def test_stuff(self):
+                            pass
+                '''
+                    )
 
     class ContextModule:
         class ContextWithOnlyMark:
@@ -175,6 +188,21 @@ class BaseLintTest(CommonSubjectTestMixin):
                     import pytest
 
                     pytestmark = stuff = {pytestmark_decl}
+
+                    class TestMyStuff:
+                        def test_stuff(self):
+                            pass
+
+                    def test_other_stuff():
+                        pass
+                ''')
+
+            class CaseChainedAssignWithUnpackAssign(IncludesUnexpectedFocused):
+                # language=py
+                source = lambda_fixture(lambda pytestmark_decl: f'''
+                    import pytest
+
+                    pytest._notreal, [pytestmark, stuff] = 'abc', [{pytestmark_decl}, 123]
 
                     class TestMyStuff:
                         def test_stuff(self):

--- a/test/ext/base_lint.py
+++ b/test/ext/base_lint.py
@@ -169,6 +169,21 @@ class BaseLintTest(CommonSubjectTestMixin):
                         pass
                 ''')
 
+            class CaseChainedAssign(IncludesUnexpectedFocused):
+                # language=py
+                source = lambda_fixture(lambda pytestmark_decl: f'''
+                    import pytest
+
+                    pytestmark = stuff = {pytestmark_decl}
+
+                    class TestMyStuff:
+                        def test_stuff(self):
+                            pass
+
+                    def test_other_stuff():
+                        pass
+                ''')
+
         class ContextWithoutOnlyMark(DoesNotIncludeUnexpectedFocused):
             # language=py
             source = static_fixture('''
@@ -192,6 +207,9 @@ class BaseLintTest(CommonSubjectTestMixin):
             a, *b, c = range(3)
             a, b, c = range(3)
             [a, b, c] = range(3)
+            
+            # Chained assignment should not cause errors
+            a = b = 3
 
             # Decorators of all kinds should not cause errors
             @staticmethod


### PR DESCRIPTION
Chained assignments were causing the flake8 ext to error.

```
/lib/python3.9/site-packages/pytest_only/ext/flake8.py", line 123, in get_pytestmark_assign_value
    raise AssertionError('when does this happen?')
AssertionError: when does this happen?
```

Changing the len check on stmt.targets to greater than or equal to 1 passes existing and added tests.  It's unclear to me if the len check was added for other reasons.  Feel free to close this PR if you want to handle it another way.